### PR TITLE
Pass relative url to app on startup

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,4 +4,10 @@
 
 require_relative 'config/environment'
 
-run Rails.application
+app = Rack::Builder.new do
+  map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
+    run CountyAdmin::Application
+  end
+end
+
+run app


### PR DESCRIPTION
Pass the RAILS_RELATIVE_URL_ROOT env along to the cap application so that cloud environments can specify the app's prefix path