### PR TITLE
Point yarn start to ./bin/webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "license-dump": "license-checker --csv --out legal/licenses.csv",
     "clean": "rimraf public/packs*",
     "build:webpacker": "./bin/webpack",
-    "start": "scripts/start.sh",
+    "start": "./bin/webpack-dev-server",
     "build": "npm-run-all --serial clean lint test build:webpacker",
     "dc:up": "docker-compose up",
     "env:get": "scripts/fetch-env.sh",


### PR DESCRIPTION
since there is no `./scripts/start.sh`, run the binstub webpacker provides ([docs](https://github.com/rails/webpacker#development)). 

related to #76 as invoking `yarn start` now simply runs `webpack-dev-server`, but as of now with (`master` @ 9f4714f) webpack is ignorant of any `.env[*]` env vars that rails _does_ pick up. That issue is addressed in #76, not by this PR.  