### PR TITLE
Destructure the enabled flag out of the data record

### DIFF
--- a/app/javascript/views/usersList/UsersList.jsx
+++ b/app/javascript/views/usersList/UsersList.jsx
@@ -24,7 +24,7 @@ const hackBtnStyles = {
 export const toFullName = ({ first_name, last_name }) =>
   `${last_name}, ${first_name}`;
 
-export const userStatusFormat = enabled => {
+export const userStatusFormat = ({ enabled }) => {
   return enabled ? 'Active' : 'Inactive';
 };
 

--- a/app/javascript/views/usersList/UsersList.test.js
+++ b/app/javascript/views/usersList/UsersList.test.js
@@ -99,11 +99,11 @@ describe('UsersList', () => {
 
       describe('userStatusFormat', () => {
         it('renders Active  for enabled', () => {
-          expect(userStatusFormat(true)).toEqual('Active');
+          expect(userStatusFormat({ enabled: true })).toEqual('Active');
         });
 
         it('renders Activefor disabled', () => {
-          expect(userStatusFormat(false)).toEqual('Inactive');
+          expect(userStatusFormat({ enabled: false })).toEqual('Inactive');
         });
       });
     });


### PR DESCRIPTION
Fix noted problem in COG-112 testing where lack of restructuring caused users to always be interpreted as enabled (Active)