### PR TITLE
Add cognito login helper

### DIFF
--- a/spec/acceptance/support/cognito_login_helper.rb
+++ b/spec/acceptance/support/cognito_login_helper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 module LoginHelper
-  def login()
+  def login
     visit ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
-    return if not current_url.include?('amazoncognito.com')
+    return unless current_url.include?('amazoncognito.com')
     fill_in 'username', with: ENV.fetch('COGNITO_USERNAME', 'no-reply@osi.ca.gov')
     fill_in 'password', with: ENV.fetch('COGNITO_PASSWORD', 'password')
     submit_btn = find('input[type="Submit"]')

--- a/spec/acceptance/support/cognito_login_helper.rb
+++ b/spec/acceptance/support/cognito_login_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module LoginHelper
+  def login()
+    visit ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
+    return if not current_url.include?('amazoncognito.com')
+    fill_in 'username', with: ENV.fetch('COGNITO_USERNAME', 'no-reply@osi.ca.gov')
+    fill_in 'password', with: ENV.fetch('COGNITO_PASSWORD', 'password')
+    submit_btn = find('input[type="Submit"]')
+    submit_btn.click
+  end
+end

--- a/spec/acceptance/user_list_page_spec.rb
+++ b/spec/acceptance/user_list_page_spec.rb
@@ -11,7 +11,6 @@ feature 'User List Page' do
   end
 
   scenario 'has a list of users' do
-    pending 'works locally fails on test bubble'
     login
     page_has_basic_text
     page_has_user_list_headers

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -2,7 +2,7 @@
 
 require 'capybara'
 require 'capybara/rspec'
-require 'acceptance/support/login_helper'
+require 'acceptance/support/cognito_login_helper'
 require 'selenium/webdriver'
 
 Capybara.register_driver :selenium do |app|


### PR DESCRIPTION
provides a cognito-ready `login` helper method for acceptance tests. 

_NOTE:_ requires env vars be provided for

- `COGNITO_USERNAME`
- `COGNITO_PASSWORD`.

Applied to the tail of #100 and invoking with:

```bash
RAILS_RELATIVE_URL_ROOT=/cap \
COGNITO_USERNAME=*** \
COGNITO_PASSWORD=*** \
bundle exec rspec spec/acceptance
```

the acceptance tests all passed 👍 