### PR TITLE
Set from (offset) to zero when pageSize changes

### DIFF
--- a/app/javascript/reducers/userListReducers.js
+++ b/app/javascript/reducers/userListReducers.js
@@ -89,7 +89,7 @@ function userListReducer(state = initialValue, { type, payload, error, meta }) {
     // TODO: fix FSA
     case USER_LIST_SET_PAGE_SIZE: {
       const size = payload;
-      return { ...state, size };
+      return { ...state, size, from: 0 };
     }
 
     case USER_LIST_SET_PAGE: {

--- a/app/javascript/reducers/userListReducers.test.js
+++ b/app/javascript/reducers/userListReducers.test.js
@@ -96,6 +96,15 @@ describe('reducer', () => {
     expect(state.size).toEqual(42);
   });
 
+  it('zeros the from param when pageSize changes', () => {
+    const before = { from: 100 };
+    const after = reducer(before, {
+      type: actionTypes.USER_LIST_SET_PAGE_SIZE,
+      payload: 42,
+    });
+    expect(after.from).toEqual(0);
+  });
+
   it('handles sort updates', () => {
     const mySort = [{ a: 1 }, { a: 1 }];
     const state = reducer(


### PR DESCRIPTION
There is a bug where we change page size, the `from` (offset) doesn't get wiped out.

ex:

 1. Say we have a 100 records in total
 1. Set `size` to something small (e.g.; 5)
 1. Scrub forward a few pages (e.g.; 4 of 20)
 1. Change the `size` to something big (e.g.; 100)
 1. 🐛

The query that went out is `{...params, size: 100, from: 40}`. 

The query that _should_ go out is `{...params, size: 100, from: 0}`