### PR TITLE
Add newrelic gem and configuration file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -62,6 +62,7 @@ plugins:
     config:
       allow_affero_copyleft: true
       allow_strong_copyleft: true
+      license_whitelist: ["New Relic"]
     issue_override:
       severity: major
 exclude_patterns:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -57,14 +57,6 @@ plugins:
   rubocop:
     enabled: true
     channel: rubocop-0-55
-  git-legal:
-    enabled: true
-    config:
-      allow_affero_copyleft: true
-      allow_strong_copyleft: true
-      license_whitelist: ["New Relic"]
-    issue_override:
-      severity: major
 exclude_patterns:
   - "config/"
   - "db/"

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'faraday', '~> 0.13.1'
 gem 'faraday_middleware', '~> 0.12.2'
 gem 'feature'
 
+gem 'newrelic_rpm', '~> 5.4', '>= 5.4.0.347'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1', '= 5.1.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    newrelic_rpm (5.4.0.347)
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -341,6 +342,7 @@ DEPENDENCIES
   foreman (~> 0.84.0)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  newrelic_rpm (~> 5.4, >= 5.4.0.347)
   pry
   pry-byebug
   puma (~> 3.7)

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,24 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated October 12, 2018, for version 5.4.0.347
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: “YOUR_KEY”
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: “County Admin”
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # Productoin deploymenrts will not use this file, but one defined for the whole CARES project.  This setting will only apply to non-prod environments.
+  agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info


### PR DESCRIPTION
Basically the same commit used by CANS.   https://github.com/ca-cwds/cans/pull/207/files

I trimmed off unused portions of the newrelic.yml. since it only can be used in development, any environment the file is activated in will have newrelic disabled.   Deployers will replace the config file for any prod environment.