### PR TITLE
Wait up to 20 seconds for loading of verificatio-data for adding a user

### DIFF
--- a/spec/acceptance/support/user_detail_page_helpers.rb
+++ b/spec/acceptance/support/user_detail_page_helpers.rb
@@ -52,8 +52,10 @@ module UserDetailPageHelper
 
   def verify_and_wait_to_complete
     click_button 'Verify User'
-    expect(page).to have_content(/Loading...|Please Verify/)
-    expect(page).to have_content('Please Verify')
+    Capybara.using_wait_time 20 do
+      expect(page).to have_button('Add User')
+      expect(page).to have_content('Please Verify')
+    end
   end
 
   def verify_and_wait_to_fail(message)


### PR DESCRIPTION
#### Which User story does this relate to (link)?
- COG-991 cleaning up a lingering flakey test

#### Brief feature description
-
The loading process of user data (from CWS/CMS) can take a long time.  We can wait up to 20 seconds now with this change, for the 'Add User' button to appear, after we load the new user data