### PR TITLE
Ignore any subqueries which don't specify a value

### DIFF
--- a/lib/elastic/user_query_builder.rb
+++ b/lib/elastic/user_query_builder.rb
@@ -30,7 +30,7 @@ module Elastic
 
     def self.query_leaves(query)
       query.map do |subquery|
-        Elastic::QueryBuilder.subquery_as_es(subquery, SUBQUERIES)
+        Elastic::QueryBuilder.subquery_as_es(subquery, SUBQUERIES) unless subquery[:value].blank?
       end.compact
     end
 

--- a/spec/lib/elastic/user_query_builder_spec.rb
+++ b/spec/lib/elastic/user_query_builder_spec.rb
@@ -71,6 +71,24 @@ describe Elastic::UserQueryBuilder do
       output = Elastic::UserQueryBuilder.get_search(input_query)
       expect(output).to eq(expected_output)
     end
+    it 'processes the missing value parameters safely' do
+      expected_output = {
+        query: { match_all: {} },
+        from: 0,
+        size: 50,
+        sort: [{ "_score": 'desc' }, { "last_name.for_sort": { order: 'asc' } },
+               { "first_name.for_sort": { order: 'asc' } }]
+      }
+      input_query = { "query": [{ "field": 'last_name' },
+                                { "field": 'first_name' },
+                                { "field": 'office_ids' },
+                                { "field": 'email' },
+                                { "field": 'racfid'  }],
+                      "sort": [], "size": 50, "from": 0 }
+
+      output = Elastic::UserQueryBuilder.get_search(input_query)
+      expect(output).to eq(expected_output)
+    end
 
     it 'processes the combination of enabled and status parameters' do
       expected_output = {


### PR DESCRIPTION
#### Which User story does this relate to (link)?
-  broken queries from latest changes

#### Brief feature description
-  Some change recently is sending query parts for users with no 'value' node in the document.  We shouldn't do it, but we should be able to recover.  This avoids the failure.