### PR TITLE
FIT-558: Serve react-wood-duck fonts locally (#390)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ package-lock.json
 /config/master.key
 /public/packs
 /public/packs-test
+/public/fonts
 /node_modules
 yarn-debug.log*
 .yarn-integrity

--- a/bin/hack-to-copy-fonts.sh
+++ b/bin/hack-to-copy-fonts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp -R node_modules/react-wood-duck/dist/fonts public/fonts

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -9,7 +9,7 @@ RUN bundle install --jobs 20 --retry 5
 COPY package.json yarn.lock /app/
 RUN yarn install --production=false --non-interactive --frozen-lockfile
 COPY . /app
-RUN NODE_ENV=production RAILS_ENV=production bundle exec rails assets:precompile
+RUN NODE_ENV=production RAILS_ENV=production bundle exec rails assets:precompile && bundle exec bin/hack-to-copy-fonts.sh
 RUN yarn install --production=false --non-interactive --frozen-lockfile
 # Required because we have mapping issues in nginx
 RUN ln -s /app/public/cap/packs /app/public/packs && ln -s /app/public/cap/assets /app/public/assets

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-router-dom": "^4.3.1",
     "react-router-redux": "^4.0.8",
     "react-table": "^6.8.6",
-    "react-wood-duck": "^0.1.79",
+    "react-wood-duck": "^0.1.82",
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-immutable": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,12 +300,14 @@
     axios "^0.16.1"
 
 "@types/node@*":
-  version "10.5.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
+  version "11.13.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.5.tgz#266564afa8a6a09dc778dfacc703ed3f09c80516"
+  integrity sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==
 
 "@types/prop-types@^15.5.2":
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.3.tgz#bef071852dca2a2dbb65fecdb7bfb30cedae2de2"
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
 "@types/react-dom@^16.0.3":
   version "16.0.6"
@@ -7422,9 +7424,9 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-wood-duck@^0.1.79:
-  version "0.1.79"
-  resolved "https://registry.yarnpkg.com/react-wood-duck/-/react-wood-duck-0.1.79.tgz#ca891991c117d6af37e704f59b13bc6849fc7c1f"
+react-wood-duck@^0.1.82:
+  version "0.1.82"
+  resolved "https://registry.yarnpkg.com/react-wood-duck/-/react-wood-duck-0.1.82.tgz#ef58e401ab1c0d39132b7206bb4ee857db21d340"
   dependencies:
     babel-runtime "^6.6.1"
     bootstrap "^3.3.7"


### PR DESCRIPTION
* Uses hacky script to move react-wood-duck fonts to proper location :unicorn:

* Fixes typo in script name :unicorn:

* Removes small formating change :unicorn:

* Uses latest react-wood-duck with final image fixes :unicorn:

#### Which User story does this relate to (link)?
-

#### Brief feature description
-
