### PR TITLE
Fit 529 fix test run error in staging pipeline

### DIFF
--- a/JenkinsfileAcceptance
+++ b/JenkinsfileAcceptance
@@ -34,11 +34,11 @@ node('int') {
       }
     } catch(Exception e) {
       currentBuild.result = "FAILURE"
-        throw e
+      notify(currentBuild.result)
+      throw e
     } finally {
       archiveArtifacts artifacts: 'tmp/*', excludes: '*/.keep', allowEmptyArchive: true
       sh "docker-compose down"
       cleanWs()
-      notify(currentBuild.result)
     }
 }

--- a/JenkinsfileAcceptance
+++ b/JenkinsfileAcceptance
@@ -21,18 +21,17 @@ node('int') {
           checkout scm
         }
       stage('Integration Acceptance Test') {
-      def testContainer = (BROWSER == 'FIREFOX') ? 'county-admin-test-firefox' : 'county-admin-test'
-      def firefox='false'
-      def testContainer='county-admin-test'
+        def firefox='false'
+        def testContainer='county-admin-test'
 
-      if(BROWSER == 'FIREFOX') {
-        firefox='true'
-        testContainer = 'county-admin-test-firefox'
+        if(BROWSER == 'FIREFOX') {
+          firefox='true'
+          testContainer = 'county-admin-test-firefox'
+        }
+        sh "docker-compose up -d --build ${testContainer}"
+        sleep 60
+        sh "docker-compose exec -T --env TZ=${TZ} --env ADD_RACFID=${ADD_RACFID} --env FIREFOX=${firefox} --env WRONG_SECURITY_RACFID=${WRONG_SECURITY_RACFID} --env COGNITO_USERNAME=${COG_USER} --env COGNITO_PASSWORD=${COG_PASS} --env COUNTY_AUTHORIZATION_ENABLED=true --env COUNTY_ADMIN_WEB_BASE_URL=https://web.integration.cwds.io/cap ${testContainer} bundle exec rspec spec/acceptance --format documentation"
       }
-      sh "docker-compose up -d --build ${testContainer}"
-      sleep 60
-      sh "docker-compose exec -T --env TZ=${TZ} --env ADD_RACFID=${ADD_RACFID} --env FIREFOX=${firefox} --env WRONG_SECURITY_RACFID=${WRONG_SECURITY_RACFID} --env COGNITO_USERNAME=${COG_USER} --env COGNITO_PASSWORD=${COG_PASS} --env COUNTY_AUTHORIZATION_ENABLED=true --env COUNTY_ADMIN_WEB_BASE_URL=https://web.integration.cwds.io/cap ${testContainer} bundle exec rspec spec/acceptance --format documentation"
-    }
     } catch(Exception e) {
       currentBuild.result = "FAILURE"
         throw e

--- a/JenkinsfileAcceptance
+++ b/JenkinsfileAcceptance
@@ -32,6 +32,7 @@ node('int') {
       sh "docker-compose up -d --build ${testContainer}"
       sleep 60
       sh "docker-compose exec -T --env TZ=${TZ} --env ADD_RACFID=${ADD_RACFID} --env FIREFOX=${firefox} --env WRONG_SECURITY_RACFID=${WRONG_SECURITY_RACFID} --env COGNITO_USERNAME=${COG_USER} --env COGNITO_PASSWORD=${COG_PASS} --env COUNTY_AUTHORIZATION_ENABLED=true --env COUNTY_ADMIN_WEB_BASE_URL=https://web.integration.cwds.io/cap ${testContainer} bundle exec rspec spec/acceptance --format documentation"
+    }
     } catch(Exception e) {
       currentBuild.result = "FAILURE"
         throw e

--- a/JenkinsfileStagingAcceptance
+++ b/JenkinsfileStagingAcceptance
@@ -1,0 +1,44 @@
+DOCKER_GROUP = 'cwds'
+DOCKER_IMAGE = 'cap'
+SLACK_CHANNEL = '#tech-cap-updates'
+
+def notify(String status) {
+  status = status ?: 'SUCCESS'
+    def colorCode = status == 'SUCCESS' ? '#00FF00' : '#FF0000'
+    def summary = """*${status}*: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':\nMore detail in console output at <${env.BUILD_URL}|${env.BUILD_URL}>"""
+
+    slackSend(
+        channel: SLACK_CHANNEL,
+        color: colorCode,
+        message: summary
+        )
+}
+node('staging') {
+  def app
+    try {
+      deleteDir()
+        stage('Checkout') {
+          checkout scm
+        }
+      stage('Staging Acceptance Test') {
+        def firefox='false'
+        def testContainer='county-admin-test'
+
+        if(BROWSER == 'FIREFOX') {
+          firefox='true'
+          testContainer = 'county-admin-test-firefox'
+        }
+        sh "docker-compose up -d --build ${testContainer}"
+        sleep 60
+        sh "docker-compose exec -T --env TZ=${TZ} --env ADD_RACFID=${ADD_RACFID} --env FIREFOX=${firefox} --env WRONG_SECURITY_RACFID=${WRONG_SECURITY_RACFID} --env COGNITO_USERNAME=${COG_USER} --env COGNITO_PASSWORD=${COG_PASS} --env COUNTY_AUTHORIZATION_ENABLED=true --env COUNTY_ADMIN_WEB_BASE_URL=http://staging.cwds.ca.gov/cap ${testContainer} bundle exec rspec spec/acceptance --format documentation"
+      }
+    } catch(Exception e) {
+      currentBuild.result = "FAILURE"
+      notify(currentBuild.result)
+      throw e
+    } finally {
+      archiveArtifacts artifacts: 'tmp/*', excludes: '*/.keep', allowEmptyArchive: true
+      sh "docker-compose down"
+      cleanWs()
+    }
+}


### PR DESCRIPTION
#### Which User story does this relate to (link)?
[FIT-529 Automation: Fix test run error when running acceptance test in staging pipeline](https://osi-cwds.atlassian.net/browse/FIT-529)

#### Brief feature description
Automation: Fix test run error when running acceptance test in staging pipeline (https://jenkins.prodctrl.cwds.io/job/staging/job/acceptance-test-cap/)
Created separate jenkinsfile for staging acceptance test to allow for the node and url specific to staging. The current jenkinsfileAcceptance is specific to integration and will be deleted as the functionality is now in jenkinsDeploy.
The compilation and other issues should be fixed with this file. However there still remains an issue due to staging firewall when building the docker test container.

#### Tests
No tests, jenkins pipeline fix only
