### PR TITLE
Fixes old bug using the wrong environment variable in Jenkins Master Build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node(node_to_run_on()) {
       }
 
       stage('Increment Tag') {
-        newTag = newSemVer(env.APP_VERSION)
+        newTag = newSemVer(env.INCREMENT_VERSION)
       }
 
       stage('Build Docker Test Image') {


### PR DESCRIPTION
Found this helping to troubleshoot a master build.