### PR TITLE
Replace chromedriver with the correct one after bundle install

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -10,8 +10,12 @@ WORKDIR app
 ADD Gemfile Gemfile.lock /app/
 RUN gem update --system
 RUN RAILS_ENV=production gem install bundler && bundle install
-ADD . /app
 
+RUN CHROME_VERSION=$(google-chrome --version | sed -r 's/[^0-9]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/g') && \
+    CHROMEDRIVER_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION) && \
+    bundle exec chromedriver-update $CHROMEDRIVER_VERSION
+
+ADD . /app
 
 ADD docker/test/run.sh /run.sh
 RUN chmod a+x /run.sh


### PR DESCRIPTION
#### Which User story does this relate to (link)?
- none.

#### Brief feature description
-   This is fixing a problem where the chrome driver and chrome browser in the test container get out of sync and we receive an error such as "Selenium::WebDriver::Error::SessionNotCreatedError:
            session not created: This version of ChromeDriver only supports Chrome version 75"