### PR TITLE
Include fuzzy counts in the match count

### DIFF
--- a/spec/acceptance/office/search_user_list_page_spec.rb
+++ b/spec/acceptance/office/search_user_list_page_spec.rb
@@ -37,7 +37,7 @@ feature 'Search User List Page' do
     expect(selected_offices[0]).to eq current_account[:office_name]
 
     sleep 2
-    first_count = page_exact_match_users.count
+    first_count = page_exact_match_users.count + page_fuzzy_match_users.count
 
     expect(first_count).to be > 0
     puts "count users #{first_count}"


### PR DESCRIPTION
#### Which User story does this relate to (link)?
- COG-955.

#### Brief feature description
-  A remaining test fails because the exact count and fuzzy count are correctly split, but the test expected to find a fuzzy match.  So, fixed that by adding the fuzzy match to the total count it expects.
