### PR TITLE
WIP Hide lock indicator on search results due to inaccuracy

### DIFF
--- a/app/javascript/views/searchUserList/SearchResultComponent.test.js
+++ b/app/javascript/views/searchUserList/SearchResultComponent.test.js
@@ -4,6 +4,7 @@ import SearchResultComponent from './SearchResultComponent'
 
 describe('SearchResultComponent', () => {
   let wrapper
+  let wrapperUnlocked
   const resultList = { id: '12345ABCD', first_name: 'firstName', last_name: 'lastName', locked: true }
 
   const officesList = [{ label: 'OFFICE ONE', value: 'office1' }, { label: 'OFFICE TWO', value: 'office2' }]
@@ -18,7 +19,17 @@ describe('SearchResultComponent', () => {
         rolesList={rolesList}
         unlockHandler={mockHandleUnlockClick}
         alertHandler={mockHandleAlert}
-        lockMessage={{ message: 'some message' }}
+        lockMessage={{ message: 'some message', unlocked: false }}
+      />
+    )
+    wrapperUnlocked = shallow(
+      <SearchResultComponent
+        value={resultList}
+        officeList={officesList}
+        rolesList={rolesList}
+        unlockHandler={mockHandleUnlockClick}
+        alertHandler={mockHandleAlert}
+        lockMessage={{ message: 'some message', unlocked: true }}
       />
     )
   })
@@ -103,6 +114,7 @@ describe('SearchResultComponent', () => {
           .dive()
           .text()
       ).toMatch('Unlock')
+      expect(wrapperUnlocked.find('IconButton').length).toEqual(0)
     })
 
     it('handles unlocking', () => {

--- a/app/javascript/views/searchUserList/SearchResults.jsx
+++ b/app/javascript/views/searchUserList/SearchResults.jsx
@@ -7,18 +7,19 @@ class SearchResults extends PureComponent {
     const { matchedUsers, officesList, rolesList, fetching } = this.props
 
     return matchedUsers.map((value, key) => {
+      const valueHideLockStatus = { ...value, locked: false }
       return (
         <SearchResultComponent
-          value={value}
+          value={valueHideLockStatus}
           key={key}
           officeList={officesList}
           rolesList={rolesList}
           fetching={fetching}
           unlockHandler={this.props.actions.unlockUser}
           lockMessage={
-            this.props.unlockedUsers[value.id]
-              ? this.props.unlockedUsers[value.id]
-              : value.locked
+            this.props.unlockedUsers[valueHideLockStatus.id]
+              ? this.props.unlockedUsers[valueHideLockStatus.id]
+              : valueHideLockStatus.locked
                 ? { unlocked: false, message: 'This user has been locked for too many failed attempts' }
                 : { unlocked: true, message: '' }
           }

--- a/app/javascript/views/searchUserList/SearchResults.test.jsx
+++ b/app/javascript/views/searchUserList/SearchResults.test.jsx
@@ -64,15 +64,13 @@ describe('SearchResults', () => {
       ).toEqual(0)
     })
 
-    it('shows the locked user message', () => {
+    it('does not show the locked user message for now', () => {
       expect(
         componentSet
           .at(1)
           .dive()
-          .find('UserMessage')
-          .render()
-          .text()
-      ).toEqual('NOT-ALLOWED')
+          .find('UserMessage').length
+      ).toEqual(0)
     })
   })
 })


### PR DESCRIPTION
#### Which User story does this relate to (link)?
- COG-1469 

#### Brief feature description
-  Until the Cognito Lock status is accurately recorded in Perry / Dora storage, we want to hide the indicator on the search page.  See COG 